### PR TITLE
GitHub Actions で Linter を走らせるようにした

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint
+
+on: push
+
+jobs:
+  ensure-newline-at-eof:
+    name: Ensure newline at end of file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Run shell script
+        run: bash ./scripts/ensure-newline-at-eof.sh
+
+  eslint-prettier:
+    runs-on: ubuntu-latest
+    name: Check code formatting
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        run: yarn
+      - name: Run shell script
+        run: yarn lint

--- a/scripts/ensure-newline-at-eof.sh
+++ b/scripts/ensure-newline-at-eof.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# ファイルの末尾が改行になっていなければ異常終了する
+
+set -x
+set -e
+
+files=`find . \( -type d -name node_modules -o -name .git -o -name target -o -name dist -o -name interp-wasm \) -prune -o -type f`
+
+for file in ${files}; do
+    test -z "$(tail -c 1 ${file})"
+done

--- a/workspaces/editor/.eslintignore
+++ b/workspaces/editor/.eslintignore
@@ -1,3 +1,3 @@
 node_modules/*
 dist/*
-wasm/*
+interp-wasm/*

--- a/workspaces/editor/.eslintrc.js
+++ b/workspaces/editor/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     },
     plugins: ['react', '@typescript-eslint', 'prettier', 'simple-import-sort'],
     rules: {
+        'eol-last': ['error', 'always'],
         indent: ['error', 4],
         'linebreak-style': ['error', 'unix'],
         quotes: ['error', 'single'],

--- a/workspaces/editor/package.json
+++ b/workspaces/editor/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "build": "webpack",
     "serve": "webpack-dev-server --open",
-    "lint": "eslint ./src/* --ext .ts,.tsx",
-    "format": "eslint --fix ./src/* --ext .ts,.tsx"
+    "lint": "eslint ./src/**/*.ts ./src/**/*.tsx && prettier --check ./*.js",
+    "format": "eslint --fix ./src/**/*.ts ./src/**/*.tsx && prettier --write ./*.js"
   },
   "description": "functional visual programming environment",
   "repository": "git@github.com:0918nobita/knights.git",

--- a/workspaces/editor/src/components/AppRoot.tsx
+++ b/workspaces/editor/src/components/AppRoot.tsx
@@ -5,7 +5,7 @@ import React, { useCallback } from 'react';
 
 import { counterOps } from '../domains/counter/operations';
 import { selectCount } from '../domains/counter/selectors';
-import { Editor } from './Editor' 
+import { Editor } from './Editor';
 
 export const AppRoot: React.FC = () => {
     const context = useFleurContext();

--- a/workspaces/editor/src/components/Editor.tsx
+++ b/workspaces/editor/src/components/Editor.tsx
@@ -2,13 +2,10 @@
 import { jsx } from '@emotion/core';
 import React from 'react';
 
-
 export const Editor: React.FC = () => {
     return (
         <React.Fragment>
-            <div className="editor-box">
-                EDITOR
-            </div>
+            <div className="editor-box">EDITOR</div>
         </React.Fragment>
     );
 };

--- a/workspaces/editor/webpack.config.js
+++ b/workspaces/editor/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const WasmPackPlugin = require('@wasm-tool/wasm-pack-plugin');
 
 module.exports = {
     mode: process.env.NODE_ENV || 'development',
@@ -18,7 +18,7 @@ module.exports = {
                 test: /\.(ts|tsx)$/,
                 exclude: /node_modules/,
                 use: {
-                    loader: "ts-loader",
+                    loader: 'ts-loader',
                 },
             },
             {
@@ -30,11 +30,11 @@ module.exports = {
     },
     plugins: [
         new HtmlWebpackPlugin({
-            template: path.join(__dirname, "index.html")
+            template: path.join(__dirname, 'index.html'),
         }),
         new WasmPackPlugin({
-            crateDirectory: path.resolve(__dirname, "../interp-rs/"),
-            outDir: '../editor/interp-wasm'
+            crateDirectory: path.resolve(__dirname, '../interp-rs/'),
+            outDir: '../editor/interp-wasm',
         }),
     ],
 };


### PR DESCRIPTION
- `Lint` ワークフローを追加
  - `ensure-newline-at-eof` ジョブ
    - ファイルの末尾が改行になっていることを確認する
  - `eslint-prettier` ジョブ
    - `yarn lint` コマンドを実行する
- `lint`, `format` コマンドが正常に動作してなかった (対象に含まれていないソースファイルが存在していた) ため修正
- eslint が `workspaces/editor/interp-wasm` ディレクトリ内のソースコードを無視するようにした
- フォーマットが行われていないままになっていた `.js`, `.tsx` ファイルにフォーマットを施した
