### PR TITLE
React.memo を用いてノードの再レンダリングを最小限に抑えた

### DIFF
--- a/workspaces/editor/src/components/Editor.tsx
+++ b/workspaces/editor/src/components/Editor.tsx
@@ -2,10 +2,10 @@
 import { jsx } from '@emotion/core';
 import React from 'react';
 
-import { ArrowLine } from './nodes/ArrowLine';
-import { IONode } from './nodes/IONode';
-import { PatternNode } from './nodes/PatternNode';
-import { ValueNode } from './nodes/ValueNode';
+import ArrowLine from './nodes/ArrowLine';
+import IONode from './nodes/IONode';
+import PatternNode from './nodes/PatternNode';
+import ValueNode from './nodes/ValueNode';
 
 export const Editor: React.FC = () => {
     const viewBox = [0, 0, 800, 600];

--- a/workspaces/editor/src/components/Editor.tsx
+++ b/workspaces/editor/src/components/Editor.tsx
@@ -2,10 +2,7 @@
 import { jsx } from '@emotion/core';
 import React from 'react';
 
-import ArrowLine from './nodes/ArrowLine';
-import IONode from './nodes/IONode';
-import PatternNode from './nodes/PatternNode';
-import ValueNode from './nodes/ValueNode';
+import { ArrowLine, IONode, PatternNode, ValueNode } from './nodes';
 
 export const Editor: React.FC = () => {
     const viewBox = [0, 0, 800, 600];

--- a/workspaces/editor/src/components/nodes/ArrowHead.tsx
+++ b/workspaces/editor/src/components/nodes/ArrowHead.tsx
@@ -13,7 +13,7 @@ type Props = {
     triangleWidth?: number;
 };
 
-export const ArrowHead: React.FC<Props> = ({
+const ArrowHead: React.FC<Props> = ({
     hx,
     hy,
     dir,
@@ -37,3 +37,5 @@ export const ArrowHead: React.FC<Props> = ({
         </React.Fragment>
     );
 };
+
+export default React.memo(ArrowHead);

--- a/workspaces/editor/src/components/nodes/ArrowLine.tsx
+++ b/workspaces/editor/src/components/nodes/ArrowLine.tsx
@@ -2,7 +2,7 @@
 import { jsx } from '@emotion/core';
 import React from 'react';
 
-import { ArrowHead } from './ArrowHead';
+import ArrowHead from './ArrowHead';
 
 type Props = {
     source: [number, number];
@@ -14,7 +14,7 @@ type Props = {
     strokeWidth?: number;
 };
 
-export const ArrowLine: React.FC<Props> = ({
+const ArrowLine: React.FC<Props> = ({
     source,
     dest,
     withHead = true,
@@ -47,3 +47,5 @@ export const ArrowLine: React.FC<Props> = ({
         </React.Fragment>
     );
 };
+
+export default React.memo(ArrowLine);

--- a/workspaces/editor/src/components/nodes/IONode.tsx
+++ b/workspaces/editor/src/components/nodes/IONode.tsx
@@ -15,7 +15,7 @@ type Props = {
     strokeWidth?: number;
 };
 
-export const IONode: React.FC<Props> = ({
+const IONode: React.FC<Props> = ({
     x,
     y,
     text = '',
@@ -52,3 +52,5 @@ export const IONode: React.FC<Props> = ({
         </React.Fragment>
     );
 };
+
+export default React.memo(IONode);

--- a/workspaces/editor/src/components/nodes/PatternNode.tsx
+++ b/workspaces/editor/src/components/nodes/PatternNode.tsx
@@ -13,7 +13,7 @@ type Props = {
     height?: number;
 };
 
-export const PatternNode: React.FC<Props> = ({
+const PatternNode: React.FC<Props> = ({
     x,
     y,
     height = 30,
@@ -43,3 +43,5 @@ export const PatternNode: React.FC<Props> = ({
         </React.Fragment>
     );
 };
+
+export default React.memo(PatternNode);

--- a/workspaces/editor/src/components/nodes/ValueNode.tsx
+++ b/workspaces/editor/src/components/nodes/ValueNode.tsx
@@ -13,7 +13,7 @@ type Props = {
     radius?: number;
 };
 
-export const ValueNode: React.FC<Props> = ({
+const ValueNode: React.FC<Props> = ({
     x,
     y,
     text = '',
@@ -38,3 +38,5 @@ export const ValueNode: React.FC<Props> = ({
         </React.Fragment>
     );
 };
+
+export default React.memo(ValueNode);

--- a/workspaces/editor/src/components/nodes/index.ts
+++ b/workspaces/editor/src/components/nodes/index.ts
@@ -1,0 +1,5 @@
+export { default as ArrowHead } from './ArrowHead';
+export { default as ArrowLine } from './ArrowLine';
+export { default as IONode } from './IONode';
+export { default as PatternNode } from './PatternNode';
+export { default as ValueNode } from './ValueNode';


### PR DESCRIPTION
``Editor`` コンポーネントが再レンダリングされると確定で ``ArrowHead``, ``ArrowLine``, ``IONode``, ``PatternNode``, ``ValueNode`` コンポーネントも再レンダリングされていたので、``React.memo`` を用いて関数コンポーネントをメモ化する (Props が更新された際に、更新前の値と比較して同じ場合は差分検出処理をスキップさせる) ことで、再レンダリングを最小限に抑えた。

``React.memo`` には第２引数で比較用関数を渡すことができるが、``components/nodes`` ディレクトリ内のソースコードで定義されているコンポーネントでは複雑な比較用関数を用意する必要がないと思われるため、第２引数は指定せずにデフォルトの shallow equal 関数を使わせるようにした。

※ React DevTools の `Highlight updates when components render` オプションを有効にして再レンダリングの発生タイミング・発生個所を確認済み