### PR TITLE
Improve type annotations and fix ESLint errors

### DIFF
--- a/workspaces/editor/.eslintrc.js
+++ b/workspaces/editor/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
         ecmaVersion: 2018,
         sourceType: 'module',
         project: './tsconfig.json',
+        tsconfigRootDir: __dirname,
         useJSXTextNode: true,
     },
     plugins: ['react', '@typescript-eslint', 'prettier', 'simple-import-sort'],

--- a/workspaces/editor/src/components/AppRoot.tsx
+++ b/workspaces/editor/src/components/AppRoot.tsx
@@ -7,7 +7,7 @@ import { counterOps } from '../domains/counter/operations';
 import { selectCount } from '../domains/counter/selectors';
 import { Editor } from './Editor';
 
-export const AppRoot: React.FC = () => {
+export const AppRoot = (): JSX.Element => {
     const context = useFleurContext();
 
     const inc = useCallback(() => {

--- a/workspaces/editor/src/components/Editor.tsx
+++ b/workspaces/editor/src/components/Editor.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 import { ArrowLine, IONode, PatternNode, ValueNode } from './nodes';
 
-export const Editor: React.FC = () => {
+export const Editor = (): JSX.Element => {
     const viewBox = [0, 0, 800, 600];
     const viewBoxStr = viewBox.join(' ');
     return (

--- a/workspaces/editor/src/components/nodes/ArrowHead.tsx
+++ b/workspaces/editor/src/components/nodes/ArrowHead.tsx
@@ -13,7 +13,7 @@ type Props = {
     triangleWidth?: number;
 };
 
-const ArrowHead: React.FC<Props> = ({
+const ArrowHead = ({
     hx,
     hy,
     dir,
@@ -21,7 +21,7 @@ const ArrowHead: React.FC<Props> = ({
     triangleWidth = 10,
     strokeColor = 'black',
     strokeWidth = 2,
-}) => {
+}: Props): JSX.Element => {
     const dirRadian = (dir * Math.PI) / 180;
     const tx = Math.cos(dirRadian) * triangleHeight,
         ty = -Math.sin(dirRadian) * triangleHeight,

--- a/workspaces/editor/src/components/nodes/ArrowLine.tsx
+++ b/workspaces/editor/src/components/nodes/ArrowLine.tsx
@@ -14,14 +14,14 @@ type Props = {
     strokeWidth?: number;
 };
 
-const ArrowLine: React.FC<Props> = ({
+const ArrowLine = ({
     source,
     dest,
     withHead = true,
     baseRadius = 15,
     strokeColor = 'black',
     strokeWidth = 2,
-}) => {
+}: Props): JSX.Element => {
     const [sx, sy] = source,
         [dx, dy] = dest;
 

--- a/workspaces/editor/src/components/nodes/IONode.tsx
+++ b/workspaces/editor/src/components/nodes/IONode.tsx
@@ -15,7 +15,7 @@ type Props = {
     strokeWidth?: number;
 };
 
-const IONode: React.FC<Props> = ({
+const IONode = ({
     x,
     y,
     text = '',
@@ -25,7 +25,7 @@ const IONode: React.FC<Props> = ({
     fillColor = 'transparent',
     strokeColor = 'red',
     strokeWidth = 2,
-}) => {
+}: Props): JSX.Element => {
     const points = [
         [x - width / 2 - dentDepth / 2, y - height / 2],
         [x - width / 2 + dentDepth / 2, y],

--- a/workspaces/editor/src/components/nodes/PatternNode.tsx
+++ b/workspaces/editor/src/components/nodes/PatternNode.tsx
@@ -13,7 +13,7 @@ type Props = {
     height?: number;
 };
 
-const PatternNode: React.FC<Props> = ({
+const PatternNode = ({
     x,
     y,
     height = 30,
@@ -21,7 +21,7 @@ const PatternNode: React.FC<Props> = ({
     fillColor = 'transparent',
     strokeColor = 'red',
     strokeWidth = 2,
-}) => {
+}: Props): JSX.Element => {
     const points = [
         [x - width / 2, y - height / 2],
         [x - width / 2, y + height / 2],

--- a/workspaces/editor/src/components/nodes/ValueNode.tsx
+++ b/workspaces/editor/src/components/nodes/ValueNode.tsx
@@ -13,7 +13,7 @@ type Props = {
     radius?: number;
 };
 
-const ValueNode: React.FC<Props> = ({
+const ValueNode = ({
     x,
     y,
     text = '',
@@ -21,7 +21,7 @@ const ValueNode: React.FC<Props> = ({
     fillColor = 'transparent',
     strokeColor = 'red',
     strokeWidth = 2,
-}) => {
+}: Props): JSX.Element => {
     /*
     const nodeProp = {
         inputPoint:[x - radius , y],


### PR DESCRIPTION
In my opinion, `React.FC` should not be used basically, so I replaced everything. and the ESLint configuration was inadequate, so I improved it and fixed all errors.