### PR TITLE
マウスドラッグでノードエディタ全体を平行移動できるようにした

### DIFF
--- a/workspaces/editor/package.json
+++ b/workspaces/editor/package.json
@@ -21,7 +21,8 @@
     "@fleur/fleur": "1.4.0",
     "@fleur/react": "3.2.0",
     "react": "16.12.0",
-    "react-dom": "16.12.0"
+    "react-dom": "16.12.0",
+    "rxjs": "^6.5.4"
   },
   "devDependencies": {
     "@babel/core": "7.8.3",

--- a/workspaces/editor/src/components/Editor.tsx
+++ b/workspaces/editor/src/components/Editor.tsx
@@ -1,16 +1,70 @@
 /* @jsx jsx */
 import { jsx } from '@emotion/core';
-import React from 'react';
+import React, { createRef, useEffect } from 'react';
+import { BehaviorSubject, fromEvent } from 'rxjs';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
 
 import { ArrowLine, IONode, PatternNode, ValueNode } from './nodes';
 
 export const Editor = (): JSX.Element => {
-    const viewBox = [0, 0, 800, 600];
-    const viewBoxStr = viewBox.join(' ');
+    const viewBoxInitSize = [0, 0, 800, 600];
+
+    const ref = createRef<SVGSVGElement>();
+
+    useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const svgElement = ref.current!;
+
+        const viewBox$ = new BehaviorSubject(viewBoxInitSize);
+
+        const viewboxSubscription = viewBox$.subscribe(size => {
+            svgElement.setAttribute('viewBox', size.join(' '));
+        });
+
+        const mouseDown$ = fromEvent<MouseEvent>(svgElement, 'mousedown');
+        const mouseMove$ = fromEvent<MouseEvent>(svgElement, 'mousemove');
+        const mouseUp$ = fromEvent(window, 'mouseup');
+
+        const dragSubscription = mouseDown$
+            .pipe(
+                switchMap(event => {
+                    event.preventDefault();
+
+                    let prevX = event.clientX;
+                    let prevY = event.clientY;
+
+                    return mouseMove$.pipe(
+                        map(moveEvent => {
+                            moveEvent.preventDefault();
+
+                            const delta = { dx: moveEvent.clientX - prevX, dy: moveEvent.clientY - prevY };
+
+                            prevX = moveEvent.clientX;
+                            prevY = moveEvent.clientY;
+
+                            return delta;
+                        }),
+                        takeUntil(mouseUp$)
+                    );
+                })
+            )
+            .subscribe(({ dx, dy }) => {
+                const viewBoxValues = viewBox$.getValue();
+                viewBoxValues[0] = viewBoxValues[0] - dx;
+                viewBoxValues[1] = viewBoxValues[1] - dy;
+                viewBox$.next(viewBoxValues);
+            });
+
+        return (): void => {
+            viewboxSubscription.unsubscribe();
+            dragSubscription.unsubscribe();
+        };
+    }, []);
+
     return (
         <React.Fragment>
             <div className="editor-container">
-                <svg viewBox={viewBoxStr} className="editor-screen">
+                <svg ref={ref} className="editor-screen">
                     <IONode x={50} y={50} text="Input" />
                     <PatternNode x={50} y={150} />
                     <ValueNode x={50} y={250} text="f" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6361,7 +6361,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.5.3:
+rxjs@^6.5.3, rxjs@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
   integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==


### PR DESCRIPTION
## スクリーンショット

↓ 画像をクリックするとそれぞれ動画付きツイートの詳細ページに飛びます

### 平行移動

[![thumbnail](https://pbs.twimg.com/ext_tw_video_thumb/1222373543331037184/pu/img/SeCmYGzyD3oNE4Oo?format=jpg&name=small)](https://twitter.com/0918nobita/status/1222373571973877762)

### 拡大縮小

[![thumbnail2](https://pbs.twimg.com/ext_tw_video_thumb/1222516217551806464/pu/img/8LUot-EuO9Iii3-W?format=jpg&name=small)](https://twitter.com/0918nobita/status/1222516280571248641)